### PR TITLE
feat: mobile map profile ui with photo carousel

### DIFF
--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -60,8 +60,10 @@ const Layout = ({ children }: Props) => {
           color="#6dbe45"
         />
       </Head>
-      <div className="relative flex h-full w-full items-center justify-center">
-        {children}
+      <div className="relative flex h-full w-full justify-center">
+        <div className="relative h-full w-full max-w-app overflow-hidden">
+          {children}
+        </div>
       </div>
     </>
   );

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -60,10 +60,8 @@ const Layout = ({ children }: Props) => {
           color="#6dbe45"
         />
       </Head>
-      <div className="relative flex h-full w-full justify-center">
-        <div className="relative h-full w-full max-w-app overflow-hidden">
-          {children}
-        </div>
+      <div className="relative flex h-full w-full flex-col">
+        {children}
       </div>
     </>
   );

--- a/src/components/layout/mobile-app-shell.tsx
+++ b/src/components/layout/mobile-app-shell.tsx
@@ -2,9 +2,17 @@ import type { ReactNode } from "react";
 
 type Props = {
   children: ReactNode;
+  /** When true, content spans the full viewport width (e.g. full-bleed map). */
+  fullWidth?: boolean;
 };
 
-export const MobileAppShell = ({ children }: Props) => {
+export const MobileAppShell = ({ children, fullWidth = false }: Props) => {
+  if (fullWidth) {
+    return (
+      <div className="relative h-full w-full flex-1 self-stretch">{children}</div>
+    );
+  }
+
   return (
     <div className="relative flex h-full w-full flex-1 self-stretch justify-center">
       <div className="relative h-full w-full max-w-app overflow-hidden">

--- a/src/components/layout/mobile-app-shell.tsx
+++ b/src/components/layout/mobile-app-shell.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react";
+
+type Props = {
+  children: ReactNode;
+};
+
+export const MobileAppShell = ({ children }: Props) => {
+  return (
+    <div className="relative flex h-full w-full flex-1 self-stretch justify-center">
+      <div className="relative h-full w-full max-w-app overflow-hidden">
+        {children}
+      </div>
+    </div>
+  );
+};

--- a/src/components/layout/mobile-chrome.tsx
+++ b/src/components/layout/mobile-chrome.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react";
+
+type Props = {
+  children: ReactNode;
+};
+
+/** Centers mobile-width UI chrome over full-bleed content. */
+export const MobileChrome = ({ children }: Props) => {
+  return (
+    <div className="pointer-events-none absolute inset-0 flex justify-center">
+      <div className="pointer-events-auto relative h-full w-full max-w-app">
+        {children}
+      </div>
+    </div>
+  );
+};

--- a/src/components/mapview/index.tsx
+++ b/src/components/mapview/index.tsx
@@ -1,27 +1,21 @@
-import Map, { Layer, Source } from "react-map-gl";
+import Map, { Layer, Source, type MapRef } from "react-map-gl";
 
 import "mapbox-gl/dist/mapbox-gl.css";
 
 // eslint-disable-next-line no-restricted-imports
 import { TripMarker } from "./marker";
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 // eslint-disable-next-line no-restricted-imports
 import { countriesLayer } from "./map-style";
+import { useProfile } from "~/components/profile/profile-provider";
+import { type Trip } from "~/models/trip";
 
 const token = process.env.NEXT_PUBLIC_MAPBOX_TOKEN ?? "";
 
-interface Trip {
-  title: string;
-  longitude: number;
-  latitude: number;
-  countryCode: string;
-  imageUrl: string;
-  date: string;
-}
-
 export const MapView = ({ trips }: { trips: Trip[] }) => {
-  // const [trips, setTrips] = useState<Trip[]>(initialTrips);
-  // const [focused, setFocused] = useState<Trip>(trips[1]);
+  const mapRef = useRef<MapRef>(null);
+  const mapLoadedRef = useRef(false);
+  const { activeTripIndex } = useProfile();
 
   const filter = useMemo(
     () => [
@@ -32,8 +26,31 @@ export const MapView = ({ trips }: { trips: Trip[] }) => {
     [trips],
   );
 
+  const flyToTrip = useCallback(
+    (tripIndex: number) => {
+      const trip = trips[tripIndex];
+      const map = mapRef.current;
+      if (!trip || !map || !mapLoadedRef.current) return;
+
+      map.flyTo({
+        center: [trip.longitude, trip.latitude],
+        zoom: 4.5,
+        duration: 2400,
+        essential: true,
+        curve: 1.42,
+        speed: 0.65,
+      });
+    },
+    [trips],
+  );
+
+  useEffect(() => {
+    flyToTrip(activeTripIndex);
+  }, [activeTripIndex, flyToTrip]);
+
   return (
     <Map
+      ref={mapRef}
       mapboxAccessToken={token}
       mapLib={import("mapbox-gl")}
       initialViewState={{
@@ -41,14 +58,17 @@ export const MapView = ({ trips }: { trips: Trip[] }) => {
         latitude: 40,
         zoom: 0,
       }}
-      // projection={"globe"} // idk what this does
+      projection="globe"
       style={{
         width: "100%",
         height: "100%",
       }}
-      // onMouseMove={onHover}
       interactiveLayerIds={["counties"]}
       mapStyle={"mapbox://styles/amho2/clrwiarp3008901pu0tpcb4xb"}
+      onLoad={() => {
+        mapLoadedRef.current = true;
+        flyToTrip(activeTripIndex);
+      }}
     >
       <Source
         id="admin-1"
@@ -56,7 +76,6 @@ export const MapView = ({ trips }: { trips: Trip[] }) => {
         url="mapbox://mapbox.country-boundaries-v1"
       >
         <Layer beforeId="waterway-label" {...countriesLayer} filter={filter} />
-        {/* <Layer beforeId="waterway-label" {...highlightLayer} filter={filter} /> */}
       </Source>
 
       {trips.map((trip, i) => {

--- a/src/components/mapview/marker.tsx
+++ b/src/components/mapview/marker.tsx
@@ -18,14 +18,16 @@ export function TripMarker({ longitude, latitude, imageUrl, date }: Props) {
     >
       <Card isFooterBlurred radius="lg" className="border-none">
         <Image
-          alt="Woman listing to music"
+          alt={date}
           className="aspect-square object-cover"
           height={100}
           src={imageUrl}
           width={100}
         />
-        <CardFooter className="absolute bottom-1 z-10 ml-1 w-[calc(100%_-_8px)] justify-between overflow-hidden rounded-large border-1 border-white/20 py-1 shadow-small before:rounded-xl before:bg-white/10">
-          <p className="w-full text-center text-tiny text-white/80">{date}</p>
+        <CardFooter className="absolute bottom-1 z-10 ml-1 w-[calc(100%_-_8px)] justify-center overflow-hidden rounded-large border-1 border-white/20 px-1 py-0.5 shadow-small before:rounded-xl before:bg-white/10">
+          <p className="w-full truncate text-center text-2xs leading-none text-white/90">
+            {date}
+          </p>
         </CardFooter>
       </Card>
     </Marker>

--- a/src/components/profile/card-stack.tsx
+++ b/src/components/profile/card-stack.tsx
@@ -3,95 +3,11 @@ import { motion } from "framer-motion";
 import move from "lodash-move";
 import Image from "next/image";
 import { useState } from "react";
+import { mockTrips } from "~/data/mock-trips";
 
 const CARDS = ["#266678", "#cb7c7a", " #36a18b", "#cda35f", "#747474"];
-const initialTrips = [
-  {
-    title: "Netherlands",
-    latitude: 52.132633,
-    longitude: 5.291266,
-    countryCode: "NLD",
-    imageUrl:
-      "https://plus.unsplash.com/premium_photo-1680028256635-17e7f3ebbb23?q=80&w=2938&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    date: "Jul 1, 2023",
-  },
-  {
-    title: "Irvine",
-    latitude: 33.645329,
-    longitude: -117.840446,
-    countryCode: "USA",
-    imageUrl:
-      "https://collegevine.imgix.net/9988b81c-a33b-452a-bfe7-a6a6de92f888.jpg",
-    date: "Aug 7, 2024",
-  },
-  {
-    title: "New York City",
-    latitude: 40.712776,
-    longitude: -74.005974,
-    countryCode: "USA",
-    imageUrl:
-      "https://plus.unsplash.com/premium_photo-1673643157179-c2dd8ea503d7?w=1400&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8bmV3JTIweW9yayUyMGNpdHl8ZW58MHx8MHx8fDA%3D",
-    date: "Sep 5, 2022",
-  },
 
-  {
-    title: "Bali",
-    latitude: -8.340539,
-    longitude: 115.091949,
-    countryCode: "IDN",
-    imageUrl:
-      "https://plus.unsplash.com/premium_photo-1668883188861-39974ed9ad99?w=1400&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8YmFsaXxlbnwwfHwwfHx8MA%3D%3D",
-    date: "Sep 9, 2023",
-  },
-
-  {
-    title: "Hong Kong",
-    latitude: 22.3193,
-    longitude: 114.1694,
-    countryCode: "CHN",
-    imageUrl:
-      "https://images.unsplash.com/photo-1576788369575-4ab045b9287e?w=1400&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8M3x8aG9uZyUyMGtvbmd8ZW58MHx8MHx8fDA%3D",
-    date: "Jul 4, 2023",
-  },
-  {
-    title: "Netherlands",
-    latitude: 52.132633,
-    longitude: 5.291266,
-    countryCode: "NLD",
-    imageUrl:
-      "https://plus.unsplash.com/premium_photo-1680028256635-17e7f3ebbb23?q=80&w=2938&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    date: "Jul 1, 2023",
-  },
-  {
-    title: "Yosemite",
-    latitude: 37.8651,
-    longitude: 119.5383,
-    countryCode: "USA",
-    imageUrl:
-      "https://images.unsplash.com/photo-1562310503-a918c4c61e38?w=1600&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8eW9zZW1pdGUlMjBuYXRpb25hbCUyMHBhcmt8ZW58MHx8MHx8fDA%3D",
-    date: "Jul 4, 2023",
-  },
-  {
-    title: "Paris, France",
-    latitude: 48.8566,
-    longitude: 2.3522,
-    countryCode: "FRA",
-    imageUrl:
-      "https://plus.unsplash.com/premium_photo-1677343985901-33e9cd84fd9b?w=1600&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8cGFyaXMlMjBmcmFuY2V8ZW58MHx8MHx8fDA%3D",
-    date: "Jul 4, 2023",
-  },
-  {
-    title: "San Francisco",
-    latitude: 37.7749,
-    longitude: -122.4194,
-    countryCode: "USA",
-    imageUrl:
-      "https://images.unsplash.com/photo-1501594907352-04cda38ebc29?w=1600&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8Z29sZGVuJTIwZ2F0ZXxlbnwwfHwwfHx8MA%3D%3D",
-    date: "Jul 4, 2023",
-  },
-];
-
-const TRIPS = initialTrips.map((trip) => trip.imageUrl);
+const TRIPS = mockTrips.map((trip) => trip.imageUrl);
 
 const CARD_OFFSET = 0;
 const SCALE_FACTOR = 0.05;

--- a/src/components/profile/card-stack.tsx
+++ b/src/components/profile/card-stack.tsx
@@ -3,22 +3,17 @@ import { motion } from "framer-motion";
 import move from "lodash-move";
 import Image from "next/image";
 import { useState } from "react";
-import { mockTrips } from "~/data/mock-trips";
 
 const CARDS = ["#266678", "#cb7c7a", " #36a18b", "#cda35f", "#747474"];
-
-const TRIPS = mockTrips.map((trip) => trip.imageUrl);
 
 const CARD_OFFSET = 0;
 const SCALE_FACTOR = 0.05;
 
-// random integer between min and max
+type Props = {
+  imageUrl: string;
+};
 
-function randomInt(min: number, max: number) {
-  return Math.floor(Math.random() * (max - min + 1) + min);
-}
-
-export const CardStack = () => {
+export const CardStack = ({ imageUrl }: Props) => {
   const [cards, setCards] = useState(CARDS);
 
   const moveToEnd = (from: number) => {
@@ -55,7 +50,7 @@ export const CardStack = () => {
             >
               <Image
                 draggable={false}
-                src={TRIPS[index + randomInt(0, TRIPS.length)]!}
+                src={imageUrl}
                 alt="your uploaded photo"
                 fill
               />

--- a/src/components/profile/photo-carousel.tsx
+++ b/src/components/profile/photo-carousel.tsx
@@ -1,0 +1,304 @@
+import { cn } from "@nextui-org/react";
+import {
+  animate,
+  motion,
+  useMotionValue,
+  useMotionValueEvent,
+  useTransform,
+  type MotionValue,
+} from "framer-motion";
+import {
+  type PointerEvent as ReactPointerEvent,
+  type WheelEvent,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+const SPACING = 44;
+const CENTER_SIZE = 56;
+
+const mod = (n: number, m: number) => ((n % m) + m) % m;
+
+type Props = {
+  photos: string[];
+  className?: string;
+  onCenteredIndexChange?: (index: number) => void;
+};
+
+function wrapTrackX(x: number, cycleWidth: number, anchor: number) {
+  let value = x;
+
+  while (value > anchor) value -= cycleWidth;
+  while (value <= anchor - cycleWidth) value += cycleWidth;
+
+  return value;
+}
+
+function CarouselPhoto({
+  index,
+  photo,
+  trackX,
+  containerWidth,
+}: {
+  index: number;
+  photo: string;
+  trackX: MotionValue<number>;
+  containerWidth: number;
+}) {
+  const itemCenter = index * SPACING;
+
+  const distance = useTransform(trackX, (tx) => {
+    return (itemCenter + tx - containerWidth / 2) / SPACING;
+  });
+
+  const scale = useTransform(distance, (d) =>
+    Math.max(0.5, 1 - Math.abs(d) * 0.16),
+  );
+  const opacity = useTransform(distance, (d) =>
+    Math.max(0.35, 1 - Math.abs(d) * 0.18),
+  );
+  const zIndex = useTransform(distance, (d) =>
+    Math.round(20 - Math.abs(d) * 2),
+  );
+
+  return (
+    <motion.div
+      className="pointer-events-none absolute top-1/2 overflow-hidden rounded-md border-2 border-white shadow-sm"
+      style={{
+        left: index * SPACING,
+        width: CENTER_SIZE,
+        height: CENTER_SIZE,
+        x: "-50%",
+        y: "-50%",
+        scale,
+        opacity,
+        zIndex,
+        transformOrigin: "center center",
+      }}
+    >
+      <img
+        src={photo}
+        alt=""
+        className="h-full w-full object-cover"
+        draggable={false}
+      />
+    </motion.div>
+  );
+}
+
+export function PhotoCarousel({
+  photos,
+  className,
+  onCenteredIndexChange,
+}: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const containerWidthRef = useRef(0);
+  const anchorRef = useRef(0);
+  const cycleWidthRef = useRef(0);
+  const onCenteredIndexChangeRef = useRef(onCenteredIndexChange);
+  const activePointerId = useRef<number | null>(null);
+  const dragStart = useRef({ pointerX: 0, trackX: 0 });
+  const lastMove = useRef({ pointerX: 0, time: 0 });
+  const inertiaAnimation = useRef<ReturnType<typeof animate> | null>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+  const trackX = useMotionValue(0);
+
+  const count = photos.length;
+  const cycleWidth = count * SPACING;
+
+  onCenteredIndexChangeRef.current = onCenteredIndexChange;
+
+  const getCenteredPhotoIndex = () => {
+    const width = containerWidthRef.current;
+    if (!width || count === 0) return 0;
+
+    const trackIndex = Math.round((width / 2 - trackX.get()) / SPACING);
+    return mod(trackIndex, count);
+  };
+
+  const reportCenteredIndex = () => {
+    onCenteredIndexChangeRef.current?.(getCenteredPhotoIndex());
+  };
+
+  const loopPhotos = useMemo(
+    () => [...photos, ...photos, ...photos],
+    [photos],
+  );
+
+  const stopInertia = () => {
+    inertiaAnimation.current?.stop();
+    inertiaAnimation.current = null;
+  };
+
+  const normalizeTrack = (value: number) => {
+    const wrapped = wrapTrackX(
+      value,
+      cycleWidthRef.current,
+      anchorRef.current,
+    );
+
+    if (wrapped !== value) {
+      trackX.set(wrapped);
+    }
+
+    return wrapped;
+  };
+
+  const snapToCenter = () => {
+    const width = containerWidthRef.current;
+    const cycle = cycleWidthRef.current;
+    if (!width || !cycle) return;
+
+    const nearestIndex = Math.round((width / 2 - trackX.get()) / SPACING);
+    const target = normalizeTrack(width / 2 - nearestIndex * SPACING);
+
+    inertiaAnimation.current = animate(trackX, target, {
+      type: "spring",
+      stiffness: 280,
+      damping: 30,
+      onComplete: reportCenteredIndex,
+    });
+  };
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container || count === 0) return;
+
+    const syncLayout = (resetPosition: boolean) => {
+      const width = container.clientWidth;
+      const anchor = width / 2 - cycleWidth;
+
+      containerWidthRef.current = width;
+      setContainerWidth(width);
+      anchorRef.current = anchor;
+      cycleWidthRef.current = cycleWidth;
+
+      if (resetPosition) {
+        trackX.set(anchor);
+      } else {
+        normalizeTrack(trackX.get());
+      }
+    };
+
+    syncLayout(true);
+    requestAnimationFrame(reportCenteredIndex);
+
+    const observer = new ResizeObserver(() => syncLayout(false));
+    observer.observe(container);
+
+    return () => observer.disconnect();
+  }, [count, cycleWidth, trackX]);
+
+  useMotionValueEvent(trackX, "change", (latest) => {
+    if (!cycleWidthRef.current) return;
+    normalizeTrack(latest);
+  });
+
+  const handleWheel = (event: WheelEvent) => {
+    event.preventDefault();
+    stopInertia();
+
+    const delta =
+      Math.abs(event.deltaX) > Math.abs(event.deltaY)
+        ? event.deltaX
+        : event.deltaY;
+
+    trackX.set(trackX.get() - delta);
+  };
+
+  const handlePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.pointerType === "mouse" && event.button !== 0) return;
+
+    stopInertia();
+    activePointerId.current = event.pointerId;
+    setIsDragging(true);
+    event.currentTarget.setPointerCapture(event.pointerId);
+
+    dragStart.current = {
+      pointerX: event.clientX,
+      trackX: trackX.get(),
+    };
+    lastMove.current = {
+      pointerX: event.clientX,
+      time: performance.now(),
+    };
+  };
+
+  const handlePointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (activePointerId.current !== event.pointerId) return;
+
+    event.preventDefault();
+
+    const delta = event.clientX - dragStart.current.pointerX;
+    trackX.set(dragStart.current.trackX + delta);
+    lastMove.current = {
+      pointerX: event.clientX,
+      time: performance.now(),
+    };
+  };
+
+  const handlePointerEnd = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (activePointerId.current !== event.pointerId) return;
+
+    activePointerId.current = null;
+    setIsDragging(false);
+    event.currentTarget.releasePointerCapture(event.pointerId);
+
+    const elapsed = performance.now() - lastMove.current.time;
+    const velocity =
+      elapsed > 0
+        ? ((event.clientX - lastMove.current.pointerX) / elapsed) * 1000
+        : 0;
+
+    if (Math.abs(velocity) > 40) {
+      inertiaAnimation.current = animate(trackX, trackX.get() + velocity * 0.3, {
+        type: "spring",
+        velocity,
+        stiffness: 90,
+        damping: 22,
+        mass: 0.6,
+        onComplete: snapToCenter,
+      });
+    } else {
+      snapToCenter();
+    }
+  };
+
+  if (count === 0) return null;
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn(
+        "relative h-16 w-full touch-none select-none overflow-hidden",
+        isDragging ? "cursor-grabbing" : "cursor-grab",
+        className,
+      )}
+      onWheel={handleWheel}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerEnd}
+      onPointerCancel={handlePointerEnd}
+    >
+      {containerWidth > 0 && (
+        <motion.div
+          className="pointer-events-none absolute left-0 top-1/2 h-0 w-max"
+          style={{ x: trackX }}
+        >
+          {loopPhotos.map((photo, index) => (
+            <CarouselPhoto
+              key={index}
+              index={index}
+              photo={photo}
+              trackX={trackX}
+              containerWidth={containerWidth}
+            />
+          ))}
+        </motion.div>
+      )}
+    </div>
+  );
+}

--- a/src/components/profile/photo-carousel.tsx
+++ b/src/components/profile/photo-carousel.tsx
@@ -16,10 +16,80 @@ import {
   useState,
 } from "react";
 
-const SPACING = 44;
-const CENTER_SIZE = 56;
+const SPACING = 18;
+const CENTER_SIZE = 48;
+const MIN_OVERLAP = 6;
+const MAX_SCALE = 1;
+const MIN_SCALE = 0.4;
+const SCALE_STEP_DECAY = 0.52;
+const MIN_OPACITY = 0.3;
 
 const mod = (n: number, m: number) => ((n % m) + m) % m;
+
+function normalizedDistanceFromCenter(
+  distance: number,
+  containerWidth: number,
+) {
+  const halfWidth = containerWidth / 2;
+  if (!halfWidth) return 0;
+
+  const pixelDistance = Math.abs(distance) * SPACING;
+  return Math.min(1, pixelDistance / halfWidth);
+}
+
+function scaleFromDistance(distance: number, containerWidth: number) {
+  const step = Math.abs(distance);
+  const stepFalloff = Math.exp(-step * SCALE_STEP_DECAY);
+  const stepScale = MIN_SCALE + (MAX_SCALE - MIN_SCALE) * stepFalloff;
+
+  const containerT = normalizedDistanceFromCenter(distance, containerWidth);
+  const edgeScale =
+    MIN_SCALE +
+    (MAX_SCALE - MIN_SCALE) * Math.cos((containerT * Math.PI) / 2);
+
+  return Math.min(stepScale, edgeScale);
+}
+
+function opacityFromDistance(distance: number, containerWidth: number) {
+  const step = Math.abs(distance);
+  const stepOpacity =
+    MIN_OPACITY + (1 - MIN_OPACITY) * Math.exp(-step * SCALE_STEP_DECAY);
+
+  const containerT = normalizedDistanceFromCenter(distance, containerWidth);
+  const edgeOpacity =
+    MIN_OPACITY +
+    (1 - MIN_OPACITY) * Math.cos((containerT * Math.PI) / 2);
+
+  return Math.min(stepOpacity, edgeOpacity);
+}
+
+function pullTowardCenter(distance: number, containerWidth: number) {
+  if (Math.abs(distance) < 0.001) return 0;
+
+  const sign = Math.sign(distance);
+  const absDistance = Math.abs(distance);
+  const wholeSteps = Math.floor(absDistance);
+  const fractionalStep = absDistance - wholeSteps;
+  let pull = 0;
+
+  for (let step = 0; step < wholeSteps; step++) {
+    const leftScale = scaleFromDistance(step, containerWidth);
+    const rightScale = scaleFromDistance(step + 1, containerWidth);
+    const touchDistance =
+      (CENTER_SIZE * leftScale + CENTER_SIZE * rightScale) / 2 - MIN_OVERLAP;
+    pull += Math.max(0, SPACING - touchDistance);
+  }
+
+  if (fractionalStep > 0) {
+    const leftScale = scaleFromDistance(wholeSteps, containerWidth);
+    const rightScale = scaleFromDistance(wholeSteps + 1, containerWidth);
+    const touchDistance =
+      (CENTER_SIZE * leftScale + CENTER_SIZE * rightScale) / 2 - MIN_OVERLAP;
+    pull += Math.max(0, SPACING - touchDistance) * fractionalStep;
+  }
+
+  return -sign * pull;
+}
 
 type Props = {
   photos: string[];
@@ -54,27 +124,37 @@ function CarouselPhoto({
   });
 
   const scale = useTransform(distance, (d) =>
-    Math.max(0.5, 1 - Math.abs(d) * 0.16),
+    scaleFromDistance(d, containerWidth),
   );
   const opacity = useTransform(distance, (d) =>
-    Math.max(0.35, 1 - Math.abs(d) * 0.18),
+    opacityFromDistance(d, containerWidth),
   );
   const zIndex = useTransform(distance, (d) =>
-    Math.round(20 - Math.abs(d) * 2),
+    Math.round(30 - Math.abs(d) * 4),
   );
+  const boxShadow = useTransform(distance, (d) =>
+    Math.abs(d) < 0.4
+      ? "0 3px 10px rgba(0,0,0,0.22)"
+      : "0 1px 2px rgba(0,0,0,0.1)",
+  );
+  const x = useTransform(distance, (d) => {
+    const pull = pullTowardCenter(d, containerWidth);
+    return pull === 0 ? "-50%" : `calc(-50% + ${pull}px)`;
+  });
 
   return (
     <motion.div
-      className="pointer-events-none absolute top-1/2 overflow-hidden rounded-md border-2 border-white shadow-sm"
+      className="pointer-events-none absolute top-1/2 overflow-hidden rounded-md border-2 border-white"
       style={{
         left: index * SPACING,
         width: CENTER_SIZE,
         height: CENTER_SIZE,
-        x: "-50%",
+        x,
         y: "-50%",
         scale,
         opacity,
         zIndex,
+        boxShadow,
         transformOrigin: "center center",
       }}
     >
@@ -273,7 +353,7 @@ export function PhotoCarousel({
     <div
       ref={containerRef}
       className={cn(
-        "relative h-16 w-full touch-none select-none overflow-hidden",
+        "relative h-12 w-full touch-none select-none overflow-hidden",
         isDragging ? "cursor-grabbing" : "cursor-grab",
         className,
       )}

--- a/src/components/profile/profile-content.tsx
+++ b/src/components/profile/profile-content.tsx
@@ -1,30 +1,27 @@
 import { ScrollShadow } from "@nextui-org/react";
 import { CardStack } from "~/components/profile/card-stack";
 import { ProfileBar } from "~/components/profile/profile-bar";
-
-// type Props = {};
+import { mockTrips } from "~/data/mock-trips";
 
 const ProfileContent = () => {
   return (
-    <div className="flex h-full w-full flex-col justify-end ">
-      <ProfileBar profileLayout />
+    <div className="flex h-full w-full justify-center">
+      <div className="relative flex h-full w-full max-w-app flex-col justify-end">
+        <ProfileBar profileLayout />
 
-      <ScrollShadow
-        className="h-full w-full pt-[190px]"
-        size={180}
-        // offset={-200}
-      >
-        {Array(10)
-          .fill(0)
-          .map((type, index) => (
-            <div className="p-8 py-6" key={index}>
-              <CardStack />
-              <h1 className="px-8 pt-2 text-center text-xl">
-                Fresno, California
-              </h1>
+        <ScrollShadow
+          className="h-full w-full pt-[190px]"
+          size={180}
+          // offset={-200}
+        >
+          {mockTrips.map((trip) => (
+            <div className="p-8 py-6" key={trip.title}>
+              <CardStack imageUrl={trip.imageUrl} />
+              <h1 className="px-8 pt-2 text-center text-xl">{trip.title}</h1>
             </div>
           ))}
-      </ScrollShadow>
+        </ScrollShadow>
+      </div>
     </div>
   );
 };

--- a/src/components/profile/profile-provider.tsx
+++ b/src/components/profile/profile-provider.tsx
@@ -19,6 +19,8 @@ type ProfileProviderType = {
   hideProfile: boolean;
   setHideProfile: Dispatch<SetStateAction<boolean>>;
   height?: number;
+  activeTripIndex: number;
+  setActiveTripIndex: Dispatch<SetStateAction<number>>;
 };
 
 const ProfileContext = createContext<ProfileProviderType | null>(null);
@@ -38,6 +40,7 @@ export function ProfileProvider({
   );
   const [username, setUsername] = useState<string>(initialState.username);
   const [hideProfile, setHideProfile] = useState<boolean>(!showProfile);
+  const [activeTripIndex, setActiveTripIndex] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
   const { height } = useDimensions(containerRef);
 
@@ -50,6 +53,8 @@ export function ProfileProvider({
     hideProfile,
     setHideProfile,
     height,
+    activeTripIndex,
+    setActiveTripIndex,
   };
 
   return (

--- a/src/components/profile/timeline-slider.tsx
+++ b/src/components/profile/timeline-slider.tsx
@@ -1,19 +1,21 @@
-import { Card, Image, cn } from "@nextui-org/react";
-import { motion } from "framer-motion";
+import { Card, cn } from "@nextui-org/react";
 import { ChevronIcon } from "~/assets/icons";
+import { PhotoCarousel } from "~/components/profile/photo-carousel";
 import { useProfile } from "~/components/profile/profile-provider";
 import { useRouter } from "next/router";
 
-const drake =
-  "https://us-tuna-sounds-images.voicemod.net/b76b232c-c50d-4704-912f-9991eb0e5513-1669755931690.jpg";
-
 export const TimelineSlider = ({ photos }: { photos: string[] }) => {
   const router = useRouter();
-  const { showProfile, setShowProfile, username, hideProfile, setHideProfile } =
-    useProfile();
+  const {
+    showProfile,
+    setShowProfile,
+    username,
+    hideProfile,
+    setHideProfile,
+    setActiveTripIndex,
+  } = useProfile();
 
   const toggleProfile = async () => {
-    console.log("LOL", { showProfile, hideProfile });
     if (!showProfile) setHideProfile(false);
     setShowProfile((p) => !p);
     showProfile
@@ -22,77 +24,28 @@ export const TimelineSlider = ({ photos }: { photos: string[] }) => {
   };
 
   return (
-    <>
-      <div className="absolute bottom-0 w-full p-4">
-        <Card
-          className={cn(
-            "relative z-20 flex h-20 w-full items-center justify-center rounded-xl p-4 transition-transform",
-            showProfile ? "translate-y-40" : "translate-y-0",
-          )}
-        >
-          <div
-            className={cn(
-              "relative h-8 w-full rounded-sm bg-foreground-500",
-              // "border-2 border-solid border-foreground",
-            )}
-          >
-            {photos.map((photo, i) => (
-              // TODO: RENDER LOW QUAL IMAGE IF NOT FULLY SHOWN
-              <div
-                key={i}
-                className={cn(
-                  "absolute h-8 w-8 bg-foreground-600",
-                  "rounded-[4px]",
-                  "border-2 border-solid border-white",
-                )}
-                style={{
-                  left: `calc(${i * 5}% - ${i * (32 / 20)}px)`,
-                }}
-              >
-                <Image
-                  className={
-                    "aspect-square h-full w-full rounded-[4px] object-cover"
-                  }
-                  alt="a"
-                  src={photo}
-                ></Image>
-              </div>
-            ))}
-          </div>
+    <div className="absolute bottom-0 w-full p-4">
+      <Card
+        className={cn(
+          "relative z-20 flex h-24 w-full items-center justify-center overflow-hidden rounded-xl px-2 py-3 transition-transform",
+          showProfile ? "translate-y-40" : "translate-y-0",
+        )}
+      >
+        <PhotoCarousel
+          photos={photos}
+          onCenteredIndexChange={setActiveTripIndex}
+        />
+      </Card>
 
-          <motion.div
-            className="left-[calc(50% - 24px)] absolute z-50 h-12 w-12 overflow-clip rounded-md border-2 border-solid border-white bg-foreground-800"
-            drag="x"
-            dragConstraints={{
-              left: -128,
-              right: 128,
-            }}
-            // stiffness={100}
-          >
-            <img
-              src={drake}
-              className=" h-full w-full object-cover"
-              draggable={false}
-            />
-          </motion.div>
-        </Card>
-
-        <button
-          className={cn(
-            "absolute left-1/2 z-40 -translate-x-1/2 px-2 transition-[bottom]",
-            showProfile ? "bottom-4 rotate-180" : "bottom-24",
-          )}
-          onClick={toggleProfile}
-        >
-          <ChevronIcon className="z-10 h-16 w-16" />
-        </button>
-
-        {/* <pre>{JSON.stringify(router, null, 2)}</pre> */}
-        {/* {JSON.stringify(profileView)}
-      <button onClick={toggleProfile}>nav</button> */}
-
-        {/* profile component */}
-      </div>
-    </>
+      <button
+        className={cn(
+          "absolute left-1/2 z-40 -translate-x-1/2 px-2 transition-[bottom]",
+          showProfile ? "bottom-4 rotate-180" : "bottom-28",
+        )}
+        onClick={toggleProfile}
+      >
+        <ChevronIcon className="z-10 h-16 w-16" />
+      </button>
+    </div>
   );
 };

--- a/src/data/mock-trips.ts
+++ b/src/data/mock-trips.ts
@@ -1,0 +1,95 @@
+import { type Trip } from "~/models/trip";
+
+/** Demo travel history — dates aligned with local holidays and seasons. */
+export const mockTrips: Trip[] = [
+  {
+    title: "Beijing, China",
+    latitude: 39.9042,
+    longitude: 116.4074,
+    countryCode: "CHN",
+    imageUrl:
+      "https://images.unsplash.com/photo-1508804185872-d7badad00f7d?w=800&auto=format&fit=crop&q=80",
+    date: "Jan 22, '23",
+  },
+  {
+    title: "Rio de Janeiro, Brazil",
+    latitude: -22.9068,
+    longitude: -43.1729,
+    countryCode: "BRA",
+    imageUrl:
+      "https://images.unsplash.com/photo-1544735716-392fe2489ffa?w=800&auto=format&fit=crop&q=80",
+    date: "Feb 21, '23",
+  },
+  {
+    title: "Tokyo, Japan",
+    latitude: 35.6762,
+    longitude: 139.6503,
+    countryCode: "JPN",
+    imageUrl:
+      "https://images.unsplash.com/photo-1522383225653-ed111181a951?w=800&auto=format&fit=crop&q=80",
+    date: "Mar 26, '23",
+  },
+  {
+    title: "Amsterdam, Netherlands",
+    latitude: 52.3676,
+    longitude: 4.9041,
+    countryCode: "NLD",
+    imageUrl:
+      "https://images.unsplash.com/photo-1534351590666-13e3e96b5017?w=800&auto=format&fit=crop&q=80",
+    date: "Apr 27, '23",
+  },
+  {
+    title: "New York City, USA",
+    latitude: 40.7128,
+    longitude: -74.006,
+    countryCode: "USA",
+    imageUrl:
+      "https://plus.unsplash.com/premium_photo-1673643157179-c2dd8ea503d7?w=800&auto=format&fit=crop&q=80",
+    date: "Jul 4, '23",
+  },
+  {
+    title: "Paris, France",
+    latitude: 48.8566,
+    longitude: 2.3522,
+    countryCode: "FRA",
+    imageUrl:
+      "https://plus.unsplash.com/premium_photo-1677343985901-33e9cd84fd9b?w=800&auto=format&fit=crop&q=80",
+    date: "Jul 14, '23",
+  },
+  {
+    title: "Bali, Indonesia",
+    latitude: -8.5069,
+    longitude: 115.2625,
+    countryCode: "IDN",
+    imageUrl:
+      "https://plus.unsplash.com/premium_photo-1668883188861-39974ed9ad99?w=800&auto=format&fit=crop&q=80",
+    date: "Aug 12, '23",
+  },
+  {
+    title: "Munich, Germany",
+    latitude: 48.1351,
+    longitude: 11.582,
+    countryCode: "DEU",
+    imageUrl:
+      "https://images.unsplash.com/photo-1513475382585-d06e58bcb0e0?w=800&auto=format&fit=crop&q=80",
+    date: "Sep 16, '23",
+  },
+  {
+    title: "Mexico City, Mexico",
+    latitude: 19.4326,
+    longitude: -99.1332,
+    countryCode: "MEX",
+    imageUrl:
+      "https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=800&auto=format&fit=crop&q=80",
+    date: "Nov 1, '23",
+  },
+  {
+    title: "Sydney, Australia",
+    latitude: -33.8688,
+    longitude: 151.2093,
+    countryCode: "AUS",
+    imageUrl:
+      "https://images.unsplash.com/photo-1570168007204-dfb528c6958f?w=800&auto=format&fit=crop&q=80",
+    date: "Dec 31, '23",
+  },
+];

--- a/src/pages/[username]/index.tsx
+++ b/src/pages/[username]/index.tsx
@@ -1,5 +1,6 @@
 import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useState } from "react";
+import { MobileChrome } from "~/components/layout/mobile-chrome";
 import { MapView } from "~/components/mapview";
 import { ProfileBarWrapper } from "~/components/profile/profile-bar-wrapper";
 import ProfileDrawer from "~/components/profile/profile-drawer";
@@ -32,10 +33,16 @@ const ProfilePage = ({
 
   return (
     <ProfileProvider initialState={{ showProfile, username }}>
-      <MapView trips={trips} />
-      <ProfileBarWrapper />
-      <TimelineSlider photos={photos} />
-      <ProfileDrawer />
+      <div className="relative h-full w-full">
+        <div className="absolute inset-0">
+          <MapView trips={trips} />
+        </div>
+        <MobileChrome>
+          <ProfileBarWrapper />
+          <TimelineSlider photos={photos} />
+          <ProfileDrawer />
+        </MobileChrome>
+      </div>
     </ProfileProvider>
   );
 };

--- a/src/pages/[username]/index.tsx
+++ b/src/pages/[username]/index.tsx
@@ -5,98 +5,13 @@ import { ProfileBarWrapper } from "~/components/profile/profile-bar-wrapper";
 import ProfileDrawer from "~/components/profile/profile-drawer";
 import { ProfileProvider } from "~/components/profile/profile-provider";
 import { TimelineSlider } from "~/components/profile/timeline-slider";
+import { mockTrips } from "~/data/mock-trips";
 import { type Trip } from "~/models/trip";
 import { redirect } from "~/utils/redirect";
 
 type Props = { username: string; showProfile: boolean };
 
-const initialTrips = [
-  {
-    title: "Netherlands",
-    latitude: 52.132633,
-    longitude: 5.291266,
-    countryCode: "NLD",
-    imageUrl:
-      "https://plus.unsplash.com/premium_photo-1680028256635-17e7f3ebbb23?q=80&w=2938&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    date: "Jul 1, 2023",
-  },
-  {
-    title: "Irvine",
-    latitude: 33.645329,
-    longitude: -117.840446,
-    countryCode: "USA",
-    imageUrl:
-      "https://collegevine.imgix.net/9988b81c-a33b-452a-bfe7-a6a6de92f888.jpg",
-    date: "Aug 7, 2024",
-  },
-  {
-    title: "New York City",
-    latitude: 40.712776,
-    longitude: -74.005974,
-    countryCode: "USA",
-    imageUrl:
-      "https://plus.unsplash.com/premium_photo-1673643157179-c2dd8ea503d7?w=1400&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8bmV3JTIweW9yayUyMGNpdHl8ZW58MHx8MHx8fDA%3D",
-    date: "Sep 5, 2022",
-  },
-
-  {
-    title: "Bali",
-    latitude: -8.340539,
-    longitude: 115.091949,
-    countryCode: "IDN",
-    imageUrl:
-      "https://plus.unsplash.com/premium_photo-1668883188861-39974ed9ad99?w=1400&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8YmFsaXxlbnwwfHwwfHx8MA%3D%3D",
-    date: "Sep 9, 2023",
-  },
-
-  {
-    title: "Hong Kong",
-    latitude: 22.3193,
-    longitude: 114.1694,
-    countryCode: "CHN",
-    imageUrl:
-      "https://images.unsplash.com/photo-1576788369575-4ab045b9287e?w=1400&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8M3x8aG9uZyUyMGtvbmd8ZW58MHx8MHx8fDA%3D",
-    date: "Jul 4, 2023",
-  },
-  {
-    title: "Netherlands",
-    latitude: 52.132633,
-    longitude: 5.291266,
-    countryCode: "NLD",
-    imageUrl:
-      "https://plus.unsplash.com/premium_photo-1680028256635-17e7f3ebbb23?q=80&w=2938&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    date: "Jul 1, 2023",
-  },
-  {
-    title: "Yosemite",
-    latitude: 37.8651,
-    longitude: 119.5383,
-    countryCode: "USA",
-    imageUrl:
-      "https://images.unsplash.com/photo-1562310503-a918c4c61e38?w=1600&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8eW9zZW1pdGUlMjBuYXRpb25hbCUyMHBhcmt8ZW58MHx8MHx8fDA%3D",
-    date: "Jul 4, 2023",
-  },
-  {
-    title: "Paris, France",
-    latitude: 48.8566,
-    longitude: 2.3522,
-    countryCode: "FRA",
-    imageUrl:
-      "https://plus.unsplash.com/premium_photo-1677343985901-33e9cd84fd9b?w=1600&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8cGFyaXMlMjBmcmFuY2V8ZW58MHx8MHx8fDA%3D",
-    date: "Jul 4, 2023",
-  },
-  {
-    title: "San Francisco",
-    latitude: 37.7749,
-    longitude: -122.4194,
-    countryCode: "USA",
-    imageUrl:
-      "https://images.unsplash.com/photo-1501594907352-04cda38ebc29?w=1600&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8Z29sZGVuJTIwZ2F0ZXxlbnwwfHwwfHx8MA%3D%3D",
-    date: "Jul 4, 2023",
-  },
-];
-
-const photos = initialTrips.map((trip) => trip.imageUrl);
+const photos = mockTrips.map((trip) => trip.imageUrl);
 
 export const getServerSideProps = (async ({ params, query, res }) => {
   const username = String(params?.username ?? "");
@@ -113,7 +28,7 @@ const ProfilePage = ({
   username,
   showProfile,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
-  const [trips, setTrips] = useState<Trip[]>(initialTrips);
+  const [trips, setTrips] = useState<Trip[]>(mockTrips);
 
   return (
     <ProfileProvider initialState={{ showProfile, username }}>

--- a/src/pages/[username]/index.tsx
+++ b/src/pages/[username]/index.tsx
@@ -96,20 +96,7 @@ const initialTrips = [
   },
 ];
 
-const photos = [
-  ...initialTrips.map((trip) => trip.imageUrl),
-  ...initialTrips.map((trip) => trip.imageUrl),
-  "https://plus.unsplash.com/premium_photo-1680028256635-17e7f3ebbb23?q=80&w=2938&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  // {
-  //   title: "Netherlands",
-  //   latitude: 52.132633,
-  //   longitude: 5.291266,
-  //   countryCode: "NLD",
-  //   imageUrl:
-  //     ,
-  //   date: "Jul 1, 2023",
-  // },
-];
+const photos = initialTrips.map((trip) => trip.imageUrl);
 
 export const getServerSideProps = (async ({ params, query, res }) => {
   const username = String(params?.username ?? "");

--- a/src/pages/[username]/index.tsx
+++ b/src/pages/[username]/index.tsx
@@ -37,10 +37,10 @@ const ProfilePage = ({
         <div className="absolute inset-0">
           <MapView trips={trips} />
         </div>
+        <ProfileDrawer />
         <MobileChrome>
           <ProfileBarWrapper />
           <TimelineSlider photos={photos} />
-          <ProfileDrawer />
         </MobileChrome>
       </div>
     </ProfileProvider>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,17 +1,34 @@
 import { type AppType } from "next/app";
+import { useRouter } from "next/router";
 
 import { api } from "~/utils/api";
 import { Providers } from "~/components/providers";
+import Layout from "~/components/layout";
+import { MobileAppShell } from "~/components/layout/mobile-app-shell";
 
 import "~/styles/globals.css";
 import "~/styles/mapbox.css";
-import Layout from "~/components/layout";
+
+const usesMobileAppShell = (asPath: string) => {
+  const path = asPath.split("?")[0] ?? asPath;
+
+  return (
+    path.startsWith("/@") || path === "/login" || path === "/upload"
+  );
+};
 
 const MyApp: AppType = ({ Component, pageProps }) => {
+  const { asPath } = useRouter();
+  const page = <Component {...pageProps} />;
+
   return (
     <Providers>
       <Layout>
-        <Component {...pageProps} />
+        {usesMobileAppShell(asPath) ? (
+          <MobileAppShell>{page}</MobileAppShell>
+        ) : (
+          page
+        )}
       </Layout>
     </Providers>
   );

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -9,13 +9,18 @@ import { MobileAppShell } from "~/components/layout/mobile-app-shell";
 import "~/styles/globals.css";
 import "~/styles/mapbox.css";
 
+const pathWithoutQuery = (asPath: string) => asPath.split("?")[0] ?? asPath;
+
 const usesMobileAppShell = (asPath: string) => {
-  const path = asPath.split("?")[0] ?? asPath;
+  const path = pathWithoutQuery(asPath);
 
   return (
     path.startsWith("/@") || path === "/login" || path === "/upload"
   );
 };
+
+const usesFullWidthShell = (asPath: string) =>
+  pathWithoutQuery(asPath).startsWith("/@");
 
 const MyApp: AppType = ({ Component, pageProps }) => {
   const { asPath } = useRouter();
@@ -25,7 +30,9 @@ const MyApp: AppType = ({ Component, pageProps }) => {
     <Providers>
       <Layout>
         {usesMobileAppShell(asPath) ? (
-          <MobileAppShell>{page}</MobileAppShell>
+          <MobileAppShell fullWidth={usesFullWidthShell(asPath)}>
+            {page}
+          </MobileAppShell>
         ) : (
           page
         )}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,6 +9,9 @@ export default {
   ],
   theme: {
     extend: {
+      maxWidth: {
+        app: "430px",
+      },
       fontFamily: {
         sans: [
           // "var(--font-sans)",


### PR DESCRIPTION
## Summary

- Constrain the app to a mobile-first max-width shell on profile routes, with full-bleed map behind centered chrome
- Add an infinite photo carousel on the timeline slider that syncs the active trip index and flies the map to the selected location
- Refine carousel visuals: overlapping photos with no gaps, feathered scale/opacity toward the edges, and a 48px centered selection state
- Refresh mock trip data and simplify profile page wiring around the new map + drawer layout

## Test plan

- [ ] Open a profile page (`/@username`) and confirm the map is full-bleed with mobile-width chrome overlaid
- [ ] Scroll/drag the bottom photo carousel and verify photos overlap continuously with no visible gaps
- [ ] Confirm the centered photo is clearly selected (~48px) and side photos scale down smoothly toward the edges
- [ ] Verify map flies to the trip location when a new photo is centered in the carousel
- [ ] Toggle the profile drawer chevron and confirm layout transitions still work
- [ ] Check non-profile routes still render without the mobile shell constraint


Made with [Cursor](https://cursor.com)