### PR TITLE
fix: restore map panning under mobile chrome overlay

### DIFF
--- a/src/components/layout/mobile-chrome.tsx
+++ b/src/components/layout/mobile-chrome.tsx
@@ -8,7 +8,7 @@ type Props = {
 export const MobileChrome = ({ children }: Props) => {
   return (
     <div className="pointer-events-none absolute inset-0 flex justify-center">
-      <div className="pointer-events-auto relative h-full w-full max-w-app">
+      <div className="pointer-events-none relative h-full w-full max-w-app">
         {children}
       </div>
     </div>

--- a/src/components/profile/profile-bar-wrapper.tsx
+++ b/src/components/profile/profile-bar-wrapper.tsx
@@ -8,7 +8,7 @@ export const ProfileBarWrapper = () => {
   return (
     <div
       className={cn(
-        "absolute top-0 w-full transition-[top]",
+        "pointer-events-auto absolute top-0 w-full transition-[top]",
         showProfile && "-top-[92px]",
       )}
     >

--- a/src/components/profile/timeline-slider.tsx
+++ b/src/components/profile/timeline-slider.tsx
@@ -24,7 +24,7 @@ export const TimelineSlider = ({ photos }: { photos: string[] }) => {
   };
 
   return (
-    <div className="absolute bottom-0 w-full p-4">
+    <div className="pointer-events-auto absolute bottom-0 w-full p-4">
       <Card
         className={cn(
           "relative z-20 flex h-24 w-full items-center justify-center overflow-hidden rounded-xl px-2 py-3 transition-transform",


### PR DESCRIPTION
## Summary
- Stop the `MobileChrome` layout wrapper from capturing pointer events across the full viewport
- Re-enable pointer events only on the profile bar and timeline carousel

## Test plan
- [ ] Pan/drag the globe on a profile page — map should move freely
- [ ] Photo carousel still scrolls and snaps on drag
- [ ] Profile bar and chevron toggle still respond to clicks


Made with [Cursor](https://cursor.com)